### PR TITLE
DOC: update link to asv docs

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -44,7 +44,7 @@ More on how to use ``asv`` can be found in `ASV documentation`_
 Command-line help is available as usual via ``asv --help`` and
 ``asv run --help``.
 
-.. _ASV documentation: https://spacetelescope.github.io/asv/
+.. _ASV documentation: https://asv.readthedocs.io/
 
 
 Writing benchmarks


### PR DESCRIPTION
* airspeed velocity documentation is now hosted at readthedocs
* update links in [`benchmarks/README.rst`](../tree/ecab276536d17cb7263d4962e6cd4ac2fedd6eeb/benchmarks) from `spacetelescope.github.io` (deprecated with no forwarding address) to the new readthedocs site for asv